### PR TITLE
ILINT-1967: Update dependecies to latest available versions

### DIFF
--- a/aws_beanstalk_tunkki.gemspec
+++ b/aws_beanstalk_tunkki.gemspec
@@ -1,8 +1,8 @@
 Gem::Specification.new do |s|
   s.name        = 'aws_beanstalk_tunkki'
-  s.version     = '1.0.4'
+  s.version     = '1.0.5'
   s.executables << 'aws_beanstalk_tunkki'
-  s.date        = '2021-03-02'
+  s.date        = '2024-02-01'
   s.summary     = "AWS Beanstalk Tunkki"
   s.description = "Tool for deploying your app to AWS ElasticBeanstalk."
   s.authors     = ["Valtteri Pajunen", "Janne Saraste"]
@@ -10,6 +10,6 @@ Gem::Specification.new do |s|
   s.files       = ["lib/aws_beanstalk_tunkki.rb"]
   s.homepage    = 'https://github.com/almamedia/aws-beanstalk-tunkki'
   s.licenses    = ['MIT']
-  s.add_runtime_dependency 'aws-sdk-elasticbeanstalk', '~> 1.26', '>= 1.26'
-  s.add_runtime_dependency 'aws-sdk-s3', '~> 1.59', '>= 1.59'
+  s.add_runtime_dependency 'aws-sdk-elasticbeanstalk', '~> 1.64', '>= 1.64'
+  s.add_runtime_dependency 'aws-sdk-s3', '~> 1.143', '>= 1.143'
 end

--- a/start_deploy.sh
+++ b/start_deploy.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/sh
-version=1.0.4
+version=1.0.5
 
 cd aws-beanstalk-tunkki
 gem build aws_beanstalk_tunkki.gemspec


### PR DESCRIPTION
Tunkin käyttämät AWS sdk palikat on +5 vuotta vanhoja, päivitetään uusimpiin mitä löytyy.
Testattu sitemapsin deploymentin kanssa ja näyttää toimivan.

Vaatii mahdollisesti:
```
      - uses: ruby/setup-ruby@v1
        with:
          ruby-version: 3.2.2
          bundler-cache: true
```
päivityksen GHA deploy.yml:iin (_kaikkiin sovelluksiin_)